### PR TITLE
Add new commands for animals, arrival and family groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ Admins have access to the following commands:
 - Redirect commands:
   - Quick link to telegram-subgroups:
     ```
-    /transport
-    /housing
-    /translations
-    /legal
+    /animals
+    /arrival
     /donations
+    /family
+    /housing
+    /legal
+    /translations
+    /transport
     ```
   - `/homepage` - browser link to webpage.
   - `/feedback` - telegram-link to sub group for technical feedback for bot.

--- a/assets/language.yaml
+++ b/assets/language.yaml
@@ -54,6 +54,12 @@ arrival-desc:
   pl: Koordynacja wolontariuszy na stacji głównej
   ru: Координация волонтеров на главной станции
   uk: Координація роботи волонтерів на головному вокзалі
+family-desc:
+  de: Hilfe für ukrainische Familien in Leipzig
+  en: Help for Ukrainian families in Leipzig
+  pl: Pomoc dla ukraińskich rodzin w Lipsku
+  ru: Помощь украинским семьям в Лейпциге
+  uk: Допомога українським родинам у Лейпцигу
 transport:
   de: Transport | 🚉 ✈️ 🚘
   en: Transport | 🚉 ✈️ 🚘

--- a/assets/language.yaml
+++ b/assets/language.yaml
@@ -42,6 +42,18 @@ redirect-remark:
   ru: 'Для получения дополнительной информации ознакомьтесь с новостями, помещенными на страницу.'
   uk: 'Для отримання додаткової інформації ознайомтеся з новинами на сторінці.'
 ## channels
+animals-desc:
+  de: Hilfe für geflüchtete Menschen mit Tieren
+  en: Help for refugees with animals
+  pl: Pomoc dla uchodźców ze zwierzętami
+  ru: Помощь беженцам c животными
+  uk: Допомога біженцям з тваринами
+arrival-desc:
+  de: Koordination der Freiwilligen am Hauptbahnhof
+  en: Coordination of volunteers at the main station
+  pl: Koordynacja wolontariuszy na stacji głównej
+  ru: Координация волонтеров на главной станции
+  uk: Координація роботи волонтерів на головному вокзалі
 transport:
   de: Transport | 🚉 ✈️ 🚘
   en: Transport | 🚉 ✈️ 🚘

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -166,18 +166,6 @@ commands:
       keyword: donations-desc
     text:
       keyword: redirect-message
-  ## Following is NOT in menu:
-  - aspects:
-      command:  '/ethermap'
-      rights:   [administrator, creator]
-      strict:   true
-      match:    '^ethermap$'
-      redirect:
-        url: 'https://getethermap.org/m/leipzig-donation-for-ukraine'
-    side-menu:
-      keyword: donations-map-desc
-    text:
-      keyword: redirect-message-donations-map
   ## 4th row
   - aspects:
       command:  '/homepage'
@@ -205,6 +193,40 @@ commands:
       keyword: feedback
     side-menu:
       keyword: feedback-desc
+    text:
+      keyword: redirect-message
+  ## Following are NOT in menu:
+  - aspects:
+      command:  '/ethermap'
+      rights:   [administrator, creator]
+      strict:   true
+      match:    '^ethermap$'
+      redirect:
+        url: 'https://getethermap.org/m/leipzig-donation-for-ukraine'
+    side-menu:
+      keyword: donations-map-desc
+    text:
+      keyword: redirect-message-donations-map
+  - aspects:
+      command:  '/animals'
+      rights:   [administrator, creator]
+      strict:   true
+      match:    '^(animal|animals)$'
+      redirect:
+        group: '@animals_leipzig_ukraine'
+    side-menu:
+      keyword: animals-desc
+    text:
+      keyword: redirect-message
+  - aspects:
+      command:  '/arrival'
+      rights:   [administrator, creator]
+      strict:   true
+      match:    '^(arrival|arrivals)$'
+      redirect:
+        group: '@arrival_leipzig_ukraine'
+    side-menu:
+      keyword: arrival-desc
     text:
       keyword: redirect-message
   # END menu commands

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -233,7 +233,7 @@ commands:
       command:  '/family'
       rights:   [administrator, creator]
       strict:   true
-      match:    '^(family|kid(s)?|familie)$'
+      match:    '^(family|kid(s)?|child(ren)?|familie)$'
       redirect:
         group:  '@kids_leipzig_ukraine'
     side-menu:

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -222,7 +222,7 @@ commands:
       command:  '/arrival'
       rights:   [administrator, creator]
       strict:   true
-      match:    '^(arrival(s)?)$'
+      match:    '^(arrival(s)?|ankunft)$'
       redirect:
         group:  '@arrival_leipzig_ukraine'
     side-menu:
@@ -233,7 +233,7 @@ commands:
       command:  '/family'
       rights:   [administrator, creator]
       strict:   true
-      match:    '^(family|kid(s)?)$'
+      match:    '^(family|kid(s)?|familie)$'
       redirect:
         group:  '@kids_leipzig_ukraine'
     side-menu:

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -213,7 +213,7 @@ commands:
       strict:   true
       match:    '^(animal(s)?|pet(s)?)$'
       redirect:
-        group: '@animals_leipzig_ukraine'
+        group:  '@animals_leipzig_ukraine'
     side-menu:
       keyword: animals-desc
     text:
@@ -222,9 +222,20 @@ commands:
       command:  '/arrival'
       rights:   [administrator, creator]
       strict:   true
-      match:    '^(arrival|arrivals)$'
+      match:    '^(arrival(s)?)$'
       redirect:
-        group: '@arrival_leipzig_ukraine'
+        group:  '@arrival_leipzig_ukraine'
+    side-menu:
+      keyword: arrival-desc
+    text:
+      keyword: redirect-message
+  - aspects:
+      command:  '/family'
+      rights:   [administrator, creator]
+      strict:   true
+      match:    '^(family|kid(s)?)$'
+      redirect:
+        group:  '@kids_leipzig_ukraine'
     side-menu:
       keyword: arrival-desc
     text:

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -211,7 +211,7 @@ commands:
       command:  '/animals'
       rights:   [administrator, creator]
       strict:   true
-      match:    '^(animal|animals)$'
+      match:    '^(animal(s)?|pet(s)?)$'
       redirect:
         group: '@animals_leipzig_ukraine'
     side-menu:

--- a/setup/config.yaml
+++ b/setup/config.yaml
@@ -237,7 +237,7 @@ commands:
       redirect:
         group:  '@kids_leipzig_ukraine'
     side-menu:
-      keyword: arrival-desc
+      keyword: family-desc
     text:
       keyword: redirect-message
   # END menu commands


### PR DESCRIPTION
This PR adds the following commands to redirect to new telegram groups:

`/animals@LeipzigBotHelpsUkraine`
`/arrival@LeipzigBotHelpsUkraine`
`/family@LeipzigBotHelpsUkraine`

Does not add new groups to `/help` response