### PR TITLE
dev-botname-case ---> staging

### DIFF
--- a/src/setup/comms.js
+++ b/src/setup/comms.js
@@ -59,20 +59,20 @@ const extra_arguments_post = (text) => {
 }
 
 /****************
- * Usage of following commands:
- * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
- *  inputs:
- *    text    = raw text input
- *    botname = name of bot to be matched
- *  returns:
- *    text     = cleaned up text (removed any botname mention)
- *    botname  = botname recognised or else undefined
- *    verified = true/false if botname recognised and matches/not, else undefined
+ * @inputs
+ *  - text    = raw text input
+ *  - botname = name of bot to be matched
+ *
+ * @returns
+ * - text     = cleaned up text (removed any botname mention)
+ * - botname  = botname recognised or else undefined
+ * - verified = true/false if botname recognised and matches/not, else undefined
+ *
+ * NOTE: matching of botname is case insensitive.
  ****************/
 const extract_communication_aspects = (extra_arguments, text_, botname_) => {
     let { command, arguments, botname, matches } = extra_arguments(text_);
-
-    const verified = (botname === undefined ? undefined : matches && (botname == botname_));
+    const verified = (botname === undefined) ? undefined : ((matches === true) && ((botname || '').toLowerCase() == (botname_ || '').toLowerCase()));
     return { command, arguments, verified };
 }
 


### PR DESCRIPTION
**Hintergrund:** manchmals sehen admins keinen Vorschlag beim Eintippen von `@...` und versuchen dann vom Kopf den Namen des Bots einzutragen. Wir wollen es ihnen erleichtern, und sie sollten nicht an die genaue Schreibweise (camel case) denken müssen.

_Was in diesem PR gemacht wurde:_

Wenn der name des angesprochenen Bots verifiziert wird, soll die Groß- / Kleinschreibung nicht berücksichtigen.